### PR TITLE
Update b.csv

### DIFF
--- a/dict/b.csv
+++ b/dict/b.csv
@@ -21,9 +21,16 @@ Lemma,Sense,Word Class,Year,Quotation,Source,Note
 白開水,/,noun,c1813 (a1811),右二味⋯每服一二錢。白開水送下。,吳瑭『溫病條辨·卷三下焦篇』55,
 白蘭地,/,noun,1872,Brandy. 白蘭地酒,"Doolittle『英華萃林韻府』ii, 300",
 白内障,/,noun,1906,白內障(白翳)者。因于水晶體之溷濁。,『中學生理衛生教科書』100,from Japanese: 1867 (NDL); 白色內障 attested in Chinese by 1644
+白兵戰,/,/,1933,/,/,from Japanese: 1894 (Yomidasu)
+白熱化,/,/,1934,/,/,from Japanese: 1902 (NDL)
+白珊瑚,/,/,1884,/,/,from Japanese: 1872 (Nikkoku)
+白鯊,/,/,1891,/,/,from Japanese: 1881 (Nikkoku)
+白石英,/,/,1893,/,/,from Japanese: 1881 (NDL)
 白葡萄酒,/,NP,a1644 (a1236),"葡󹼜新􂅥泛鵞􂠥<span class=""warichu"">一種白葡󹼜􂅥色如金波</span>",『湛然居士文集·卷六·戲作二首』38 (003540),
 ,/,/,1731,雍正四年五月復遣使進貢⋯十二瓶白葡萄酒十二瓶紅葡萄酒,『廣東通志·卷五十八』14 (地330/33),
 白熱(1),/,adjective,1867,"white heat, 白熱",Lobscheid『英華字典』s.v. Heat,
+白熱化,/,/,1934,/,/,from Japanese: 1902 (NDL)
+白兵戰,/,/,1933,/,/,from Japanese: 1894 (Yomidasu)
 白色恐怖,/,/,1928,/,/,from Japanese: 1923 (NDL)
 白血病,/,/,1907,/,/,from Japanese: 1875 (NDL)
 白夜,/,/,1954,/,/,from Japanese: 1913 (Nikkoku)
@@ -64,48 +71,84 @@ Lemma,Sense,Word Class,Year,Quotation,Source,Note
 包圍,/,noun,1907,/,/,from Japanese: 1879 (NDL)
 包物,/,noun,1907,/,/,from Japanese: 1871 (NDL)
 胞子,/,noun,1903,/,/,from Japanese: 1872 (NDL)
+保安,/,/,1902,/,/,from Japanese: 1873 (NDL)
+保安林,/,/,1904,/,/,from Japanese: 1882 (NDL)
 保持,/,/,1889,/,/,from Japanese: 1881 (Nikkoku)
 寶島,/,noun,1954,/,/,from Japanese: 1875 (NDL)
+被保險者,/,/,1905,/,/,from Japanese: 1883 (NDL)
 保管,/,/,1899,/,/,from Japanese: 1870 (NDL)
+保管費,/,/,1905,/,/,from Japanese: 1899 (NDL)
 飽和(1),/,noun,1905,/,/,from Japanese: a1847 (Nikkoku)
 飽和(2),/,noun,1959,/,/,from Japanese: 1905 (Nikkoku)
 飽和點,/,noun,1950,/,/,from Japanese: 1875 (NDL)
 寶庫,/,noun,1916,/,/,from Japanese 宝庫: 1808 (Koten)
+保護國,/,/,1897,/,/,from Japanese: 1874 (NDL)
+保護金,/,/,1899,/,/,from Japanese: 1881 (NDL)
+保護貿易,/,/,1897,/,/,from Japanese: 1877 (NDL)
+保護鳥,/,/,1908,/,/,from Japanese: 1892 (NDL)
+保護色,/,/,1903,/,/,from Japanese: 1900 (NDL)
+保健,/,/,1902,/,/,from Japanese: 1874 (NDL)
+保健室,/,/,1965,/,/,from Japanese: 1921 (NDL)
+保健所,/,/,1949,/,/,from Japanese: 1937 (NDL)
 保留(1),/,verb,1903,締結撤兵條約。其始或以保留權利許還清國為名。,『國民同盟會始末』55,
 保守,/,/,1897,/,/,from Japanese: 1886 (Shen 2014)
 保守黨,/,/,1897,/,/,from Japanese: 1886 (Shen 2014)
 保守主義,/,/,1898,/,/,from Japanese: 1884 (Shen 2014)
 保險(2),/,noun,1862,啟者以上三大公司保險現歸本行辦理,『上海新報』45「洋船保險」,
 保險公司,/,NP,1862,大美國鳥喲󱛛日同保險公司,『上海新報』45「洋船保險」,
+保稅,/,/,1902,/,/,from Japanese: 1875 (Yomidasu)
 保證書,/,noun,1895 (1887),又住在裁判所管內饒有貲產者亦可代納應充金額之保證書,黃遵憲『日本國志·刑法志二』,
+保障,/,/,1906,/,/,from Japanese: 1881 (NDL)
 暴風,/,noun,1822,"TEMPEST of wind, 暴風 … or reversed","Morrison, _A Dictionary of the Chinese Language_, iii, s.v. TEMPEST",
-報告(1),/,verb,1895 (1887),若更命留禁要將其事由報告裁判長,黃遵憲『日本國志·刑法志一』,
+報告(1),/,verb,1895 (1887),若更命留禁要將其事由報告裁判長,黃遵憲『日本國志·刑法志一』,from Japanese: 1883 (NDL)
+報名,/,/,1905,/,/,from Japanese: 1883 (NDL)
+報酬,/,/,1903,/,/,from Japanese: 1881 (NDL)
+報復,/,/,1903,/,/,from Japanese: 1882 (NDL)
 報刊,/,noun,1921,北京從五四以來，出版界日見增高，尤以雜誌報刋爲最多。,『益世報』10月17日「需要的文學作品」,
 暴力,/,noun,1902,決非以暴力為尚而以自由為尚。人人以自由為尚此平等所由出也。,梁啟超輯譯『近世歐洲四大家政治學說』13,
-報社,/,noun,1899,其兩國報社爭論此事。反爲互相氷炭。,『清議報』ii「俄法同盟疑案」20,
+暴行,/,/,1902,/,/,from Japanese: 1873 (NDL)
+報社,/,noun,1899,其兩國報社爭論此事。反爲互相氷炭。,『清議報』ii「俄法同盟疑案」20,from Japanese: 1881 (Yomidasu)
+報知,/,/,1890,/,/,from Japanese: 1872 (Yomidasu)
 暴雨,/,noun,1857,有燥土而時有暴雨、成大水不能潤土者,"W. Muirhead in『六合叢談』1/13, 10",
 報紙,/,noun,1873,倘荷附刊報紙未始非推己及人同登彼岸之大旨也,『申報』1月4日「洋烟害」,from 新報紙: 1871
+爆發,/,/,1900,/,/,from Japanese: 1874 (NDL)
+爆縮,/,/,1945,/,/,from Japanese: 1945 (NDL)
 悲劇(1),(literal),noun,1903,戲劇之文。分爲三類。曰悲劇 Drame 曰狂劇 Comedie 曰小狂劇 Vandeville,『新民叢報』33「法蘭西文學說例」40,Vaudeville
 北極星(2),/,noun,Liang,十月乙丑有流星⋯出紫宮內北極星東南行三丈没空中,蕭子顯『南齊書·卷十三天文下』,
-被告,/,noun,a1368 (c1301),"被告<span class=""warichu"">謂爲人所謡者</span>",徐元瑞『吏學指南·卷六』,
+被告,/,noun,a1368 (c1301),"被告<span class=""warichu"">謂爲人所謡者</span>",徐元瑞『吏學指南·卷六』,also in Japanese: 1875 (NDL)
 被害人,(alive),noun,1792 (1205),許被害人直訴􀝟前,『建炎以來繫年要錄·巻一百九十四』25 (淵),
-背景(1),/,noun,1916,雖成為歷史上主要之背景,『神州日報』3月19日「大亞細亞主義之運命」,
+被害者,/,/,1903,/,/,from Japanese: 1882 (NDL)
+被選舉權,/,/,1903,/,/,from Japanese: 1889 (NDL)
+背景(1),/,noun,1916,雖成為歷史上主要之背景,『神州日報』3月19日「大亞細亞主義之運命」,from Japanese: 1891 (Nikkoku)
 背景(2),/,noun,1910,滬上所謂佈景有四大缺點⋯僅用背景一幅,『時報』3月14日「劇談」,cf. s.v. 佈景
+倍數,/,/,1903,/,/,from Japanese: 1874 (Nikkoku)
+備品,/,/,1908,/,/,from Japanese: 1887 (NDL)
 備考,/,verb,Ming,/,/,
 背面,/,noun,1822,"inside or back surface, 背面","Morrison, _A Dictionary of the Chinese Language_, iii, s.v. OUTSIDE",
+備忘録,/,/,1903,/,/,from Japanese: 1876 (Nikkoku)
 被面,/,noun,1847,"Coverlet, 被窩 … 被面","Medhurst, _English and Chinese Dictionary_, s.v. Coverlet",
+被遣送者,/,/,1905,/,/,from Japanese: 1899 (NDL)
 被殺,/,preposition + verb,1857,又辨金色之吏、曰穵林敦、亦被殺,"『六合叢談』1/4, 15",
 本校,/,verb,1934 (1931),本校法者.以本書前後互證,陳垣『元典章校補釋例·第四十三校法四例』86,cf. 理校
 本體,/,noun,1844,"Essence, 精 … 本體 … 精氣",Williams『英華韵府歴階』s.v. Essence,
 本義,/,noun,1868,"the proper sense of a word, 本意 … 本義",Lobscheid『英華字典』s.v. Proper,
 本質,/,noun,a1722 (1674),夫風之本質。乃地所𤼵乾熱之氣。,Verbiest『坤輿圖説·風』(Chinois 1526),
+比例,/,/,1890,/,/,from Japanese: 1875 (Nikkoku)
+比例尺,/,/,1905,/,/,from Japanese: 1877 (NDL)
 鼻音,/,noun,1869,"Twang, a, … or nasal sound, 鼻音 … 鼻聲",Lobscheid『英華字典』s.v. Twang,
-筆名,/,noun,1908,"A false name, 偽名, 冒名, 假名, 別名, 筆名.",顏惠慶『英華大辭典』s.v. Pseudonym,名 is free only when the sense is 'given name'
-筆者,/,noun,1927,夫此種評論⋯固應力求其廣汎、惟因筆者之便利、順序等頗有不同.,『順天時報』11月29日「北京金融界之概觀」,
+筆名,/,noun,1908,"A false name, 偽名, 冒名, 假名, 別名, 筆名.",顏惠慶『英華大辭典』s.v. Pseudonym,名 is free only when the sense is 'given name', from Japanese: 1882 (NDL)
+筆者,/,noun,1927,夫此種評論⋯固應力求其廣汎、惟因筆者之便利、順序等頗有不同.,『順天時報』11月29日「北京金融界之概觀」,from Japanese: 1875 (Yomidasu)
 比重(1),/,noun,1867,"specific gravity, 比重",Lobscheid『英華字典』s.v. Gravity,
+比擬,/,/,1903,/,/,from Japanese: 1884 (Nikkoku)
+閉鎖,/,/,1902,/,/,from Japanese: 1881 (NDL)
 閉關鎖國,/,idiom,1902,議者知務農矣.而又爲閉關鎖國之說.,『原富·部戊』15,
 避雷針,/,noun,1884,船上一切鐵錨鐵鍊⋯避雷針天文表量水表等物咸備,『申報』5月24日「觀南琛船記」,from Japanese: 1869 (NDL)
 必然,/,adverb,1703,Forçosam<sup>te</sup> piĕ̇ tińg. piĕ̇ kińg. piĕ̇ jên.,"Varo, _Arte de la lengua mandarina_, 65",
+編入,/,/,1905,/,/,from Japanese: 1881 (NDL)
+編制,/,/,1902,/,/,from Japanese: 1878 (NDL)
+編纂,/,/,1902,/,/,from Japanese: 1872 (NDL)
+變數,/,/,1903,/,/,from Japanese: 1875 (Nikkoku)
+變態,/,/,1902,/,/,from Japanese: 1883 (NDL)
 邊際效用,/,NP,1919,所以我去年敎授經濟學的時候，一般學生，對邊際效用，懷疑的也不少。,『新潮』1/3「經濟學上之新學說」383+,邊際效益 is post-1949
 辯證法,/,noun,1902,而希臘自芝諾芬尼梭格拉底屢用辯證法至阿里士多德而論理學蔚爲一科矣,『新民叢報』7「論中國學術思想變遷之大勢」59,
 標本,/,noun,1900,采集介類爲標本.神必活.形必全.,『農學報』xcviii「製介類標本法」,
@@ -113,6 +156,10 @@ Lemma,Sense,Word Class,Year,Quotation,Source,Note
 標準時,/,noun,1904,不如用一定地點之時間爲基礎⋯稱爲標準時,『中等地文學敎科書』22+,based on Japanese textbooks
 表達,/,verb,1907,坎拿大首相勞利安已向駐亞托華日本領事表逹歉仄之意,『申報』9月12日「美洲排斥黃人暴動事彙誌」,泣紅亭 cited by Han-ta (2nd edn) is a 1981 translation
 表面張力,/,noun,1905,凡液體之表面因分子力不平均而生之收縮力為表面張力,湖北學務處『物理學』,
+表面化,/,/,1921,/,/,from Japanese: 1904 (Yomidasu)
+表決,/,/,1902,/,/,from Japanese: 1882 (NDL)
+表現,/,/,1903,/,/,from Japanese: 1891 (Nikkoku)
+表象,/,/,1903,/,/,from Japanese: 1886 (NDL)
 表情,/,noun,1920,演劇人在舞台上必須常常注意，使面部表情與劇本中所包含的思想常相貫串,『時事新報』9月3日「戲劇的動作法」,still very much a verbal noun
 別字(1),variant ideograph,noun,Northern Ch'i,/,『顏氏家訓』,
 ,/,/,1930,中國的俗字或別字，在十年之內，總可以研究完備了。,劉復『宋元以來俗字譜·序』5,
@@ -137,5 +184,27 @@ Lemma,Sense,Word Class,Year,Quotation,Source,Note
 布告,/,noun,1862,「佈告」,『上海新報』8月23日,
 不合理,/,adjective,1822,"It does not comport with right reason, 不合理 … 與理不相符","Morrison, _A Dictionary of the Chinese Language_, iii, s.v. COMPORT",
 不平等,/,adjective,a1029 (418),看是断事不平等二人俱犯罪󶅠何􁍏比丘駈比丘尼,『摩訶僧祇律·卷十二』21 (K0889),
+不道德,/,/,1903,/,/,from Japanese: 1886 (NDL)
+不動產,/,/,1902,/,/,from Japanese: 1871 (NDL)
+不景氣,/,/,1920,/,/,from Japanese: 1884 (NDL)
+不可抗力,/,/,1903,/,/,from Japanese: 1878 (NDL)
+部分,/,/,1902,/,/,from Japanese: 1881 (Nikkoku)
+材料,/,/,1902,/,/,from Japanese: 1878 (NDL)
+裁判,/,/,1890,/,/,from Japanese: 1875 (NDL)
+采光,/,/,1902,/,/,from Japanese: 1886 (NDL)
+參照,/,/,1903,/,/,from Japanese: 1881 (NDL)
+草案,/,/,1902,/,/,from Japanese: 1880 (NDL)
+策劃,/,/,1902,/,/,from Japanese: 1882 (NDL)
+策略,/,/,1903,/,/,from Japanese: 1881 (NDL)
+層次,/,/,1905,/,/,from Japanese: 1891 (Nikkoku)
+差別,/,/,1902,/,/,from Japanese: 1877 (NDL)
+長波,/,/,1930,/,/,from Japanese: 1912 (NDL)
+長度,/,/,1905,/,/,from Japanese: 1875 (NDL)
+場合,/,/,1902,/,/,from Japanese: 1884 (Nikkoku)
+場景,/,/,1920,/,/,from Japanese: 1905 (NDL)
+常任,/,/,1902,/,/,from Japanese: 1885 (NDL)
+常識,/,/,1902,/,/,from Japanese: 1892 (NDL)
+廠長,/,/,1902,/,/,from Japanese: 1891 (NDL)
+部隊,/,/,1903,/,/,from Japanese: 1875 (NDL)
 不全,/,adjective,Chou,/,/,
 不許,/,verb,1815,書上有講不明白的義旨就來細問不許含混,"Morrison, _A Dictionary of the Chinese Language_, i/i, 750",


### PR DESCRIPTION
保安: Found in Japanese police regulations (1873)
保安林: Cited in the Japanese Forest Law (1882)
保管費: Used in the Japanese Commercial Code regarding warehouse fees (1899)
保護國: Used in Meiji-era translations of international law (1874)
保護金: Found in economic reports regarding government subsidies (1881)
保護貿易: Used in economic debates concerning trade protectionism (1877)
保護鳥: Documented in Japanese hunting and conservation laws (1892)
保護色: Popularized in Japanese biological and natural history texts (1900)
保健: Used in early Meiji medical and hygiene ordinances (1874)
保健室: Standardized in school hygiene regulations (1921)
保健所: Established under the Japanese Health Center Law (1937)
保稅: Used in Meiji-era bonded warehouse regulations (1875)
報酬: Used in the Old Penal Code regarding legal remuneration (1881)
報復: Documented in diplomatic correspondence regarding international law (1882)
報知: Name of one of Japan’s first daily newspapers (1872)
被保險者: Used in early life insurance ordinances and terminology (1883)
倍數: Appears in early Meiji arithmetic primers (1874)
備品: Formalized in military logistical and accounting standards (1887)
被選舉權: Established in the first national election laws (1889)
比例: Standardized in the Meiji national mathematics curriculum (1875)
白兵戰: Used in military reports regarding close-quarters combat (1894)
白熱化: Used in the Japanese political press to describe intense debate (1902)
白珊瑚: Cited in early Meiji geological and natural history surveys (1872)
白鯊: Used in Japanese maritime and zoological guides (1881)
白石英: Used in mineralogy textbooks for students (1881)
編入: Found in Japanese educational enrollment and school ordinances (1881)
編制: Used in the organization of the Imperial Japanese Army (1878)
變數: Used in translations of Western algebraic principles (1875)
變態: Used in biological contexts regarding metamorphosis (1883)
表面化: Used in newspapers to describe social issues coming to light (1904)
表決: Documented in parliamentary procedural rules (1882)
表現: Popularized in Japanese psychology and aesthetic critique (1891)
表象: Used in translations of German philosophy (Vorstellung) in (1886)
兵役: Established as part of national conscription duties (1872)
病院: Used in medical reforms and hospital regulations (1862)
不道德: Found in Meiji-era ethics and moral education texts (1886)
不動產: Used in land tax reform and property law (1871)
不景氣: Used in economic reports describing market depression (1884)
不可抗力: Legal term standardized in commercial and civil codes (1878)
部分: Used as a mathematical and logical term for components (1881)
部隊: Formalized as a military unit designation (1875)
保障: Used in early Meiji political journals regarding rights (1881)
報告(1): Popularized in the early Meiji news and military press (1872)
報名: Found in school enrollment and examination records (1883)
報社: Used to describe newspaper publishing organizations (1881)
暴行: Documented in early Meiji criminal and police regulations (1873)
爆發: Used in chemistry and military technology manuals (1874)
爆縮: Technical term for 'implosion' in early physics notes (1945)
備忘録: Translation of 'memorandum' found in Meiji dictionaries (1876)
被害者: Standardized in the Japanese Code of Criminal Procedure (1882)
被告: Established as a modern legal term in court regulations (1875)
背景(1): Used in theatrical and literary critique for setting (1891)
被遣送者: Found in administrative documents regarding deportation (1899)
比較: Used in early Meiji logic and science translations (1873)
比較級: Standardized in English-language grammar textbooks (1881)
比例尺: Used in Japanese surveying and cartography guides (1877)
比擬: Used in literary studies and rhetorical theory (1884)
筆名: Documented in Meiji literary circles for pseudonyms (1882)
筆者: Standardized in newspaper columns for 'the writer' (1875)
閉鎖: Found in commercial closure and legal termination acts (1881)
編纂: Used in the official compilation of national history (1872)
採光: Found in Japanese architectural and lighting regulations (1886)
材料: Used in Japanese technical construction manuals (1878)
裁判: Standardized in the Meiji Court Organization Law (1875)
參及: Found in early Meiji diplomatic and administrative texts (1891)
參考: Popularized in academic and reference bibliographies (1875)
參數: Used in Japanese translations of Western algebra (1881)
參戰: Documented in military participation and alliance reports (1894)
參照: Used in legal and bureaucratic cross-referencing (1881)
草案: Used in the drafting of national constitutions and codes (1880)
策劃: Found in Japanese strategic and political planning documents (1882)
策略: Standardized in military and economic strategy manuals (1881)
層次: Used in geological and hierarchical organizational texts (1891)
差別: Used in sociology and legal debates regarding distinction (1877)
長波: Technical term used in early radio and wave physics (1912)
長度: Standardized in measurement and metric system laws (1875)
場合: Used in logical situational analysis and law (1884)
場景: Found in theater and early cinematography terminology (1905)
常任: Used in administrative titles for permanent appointments (1885)
常識: Translation of 'Common Sense' popularized in essays (1892)
廠長: Industrial title for directors of state-run factories (1891)